### PR TITLE
feature(azure): configure instances with user data

### DIFF
--- a/sct.py
+++ b/sct.py
@@ -201,7 +201,7 @@ def provision_resources(backend, test_name: str, config: str):
     params = create_sct_configuration(test_name=test_name)
     test_config = get_test_config()
     test_id = test_config.test_id()
-    if test_id is None or test_id == "None":
+    if not test_id or test_id == "None":
         raise ValueError("No test_id was provided. Aborting provisioning.")
     localhost = LocalHost(user_prefix=params.get("user_prefix"), test_id=test_config.test_id())
 

--- a/sct.py
+++ b/sct.py
@@ -219,7 +219,7 @@ def provision_resources(backend, test_name: str, config: str):
         layout = SCTProvisionLayout(params=params)
         layout.provision()
     elif backend == "azure":
-        provision_sct_resources(sct_config=params)
+        provision_sct_resources(sct_config=params, test_config=test_config)
     else:
         raise ValueError(f"backend {backend} is not supported")
 

--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -125,6 +125,10 @@ class AzureNode(cluster.BaseNode):
     def _get_private_ip_address(self) -> str | None:
         return self._instance.private_ip_address
 
+    def configure_remote_logging(self) -> None:
+        """Remote logging configured upon vm provisioning using UserDataObject"""
+        return
+
 
 class AzureCluster(cluster.BaseCluster):   # pylint: disable=too-many-instance-attributes
     def __init__(self, image_id, root_disk_size,  # pylint: disable=too-many-arguments, too-many-locals
@@ -188,7 +192,8 @@ class AzureCluster(cluster.BaseCluster):   # pylint: disable=too-many-instance-a
         definitions = []
         for node_index in range(self._node_index + 1, self._node_index + count + 1):
             definitions.append(
-                generate_instance_definition(self.params, node_type=self.node_type, region=region, index=node_index)
+                generate_instance_definition(self.params, test_config=self.test_config, node_type=self.node_type, region=region,
+                                             index=node_index)
             )
         return provision_instances_with_fallback(self.provisioners[dc_idx], definitions=definitions, pricing_model=pricing_model,
                                                  fallback_on_demand=self.params.get("instance_provision_fallback_on_demand"))

--- a/sdcm/cluster_azure.py
+++ b/sdcm/cluster_azure.py
@@ -16,9 +16,10 @@ from functools import cached_property
 from typing import Dict, List
 
 from sdcm import cluster
-from sdcm.keystore import KeyStore
 from sdcm.provision.azure.provisioner import AzureProvisioner
-from sdcm.provision.provisioner import InstanceDefinition, PricingModel, VmInstance
+from sdcm.provision.provisioner import PricingModel, VmInstance
+from sdcm.sct_provision.azure.azure_instance_request_definition_builder import generate_instance_definition
+from sdcm.sct_provision.instances_provider import provision_instances_with_fallback
 from sdcm.utils.decorators import retrying
 
 LOGGER = logging.getLogger(__name__)
@@ -38,14 +39,14 @@ class AzureNode(cluster.BaseNode):
 
     def __init__(self, azure_instance: VmInstance,  # pylint: disable=too-many-arguments
                  credentials, parent_cluster,
-                 node_prefix='node', node_index=1, user_name='root',
+                 node_prefix='node', node_index=1,
                  base_logdir=None, dc_idx=0):
         region = parent_cluster.params.get('azure_region_name')[dc_idx]
         name = f"{node_prefix}-{region}-{node_index}".lower()
         self.node_index = node_index
-        self._instance: VmInstance = azure_instance
+        self._instance = azure_instance
         ssh_login_info = {'hostname': None,
-                          'user': user_name,
+                          'user': azure_instance.user_name,
                           'key_file': credentials.key_file,
                           'extra_ssh_options': '-tt'}
         super().__init__(name=name,
@@ -171,7 +172,6 @@ class AzureCluster(cluster.BaseCluster):   # pylint: disable=too-many-instance-a
             node = AzureNode(azure_instance=instance,
                              credentials=self._credentials[0],
                              parent_cluster=self,
-                             user_name=self._user_name,
                              node_prefix=self.node_prefix,
                              node_index=node_index,
                              base_logdir=self.logdir,
@@ -181,28 +181,17 @@ class AzureCluster(cluster.BaseCluster):   # pylint: disable=too-many-instance-a
         except Exception as ex:
             raise CreateAzureNodeError('Failed to create node: %s' % ex) from ex
 
-    def _create_instances(self, count, dc_idx=0):
+    def _create_instances(self, count, dc_idx=0) -> List[VmInstance]:
         region = self.params.get('azure_region_name')[dc_idx]
         assert region, "no region provided, please add `azure_region_name` param"
         pricing_model = PricingModel.SPOT if 'spot' in self.instance_provision else PricingModel.ON_DEMAND
-        instances = []
+        definitions = []
         for node_index in range(self._node_index + 1, self._node_index + count + 1):
-            instance_definition = InstanceDefinition(
-                name=f"{self._node_prefix}-{region}-{node_index}".lower(),
-                image_id=self._image_id,
-                type=self._instance_type,
-                user_name=self._user_name,
-                tags=self.tags,
-                ssh_public_key=KeyStore().get_gce_ssh_key_pair().public_key.decode()
+            definitions.append(
+                generate_instance_definition(self.params, node_type=self.node_type, region=region, index=node_index)
             )
-            instances.append(self._provision_instance(instance_definition=instance_definition,
-                                                      pricing_model=pricing_model, dc_idx=dc_idx))
-        return instances
-
-    @retrying(n=3, sleep_time=1)
-    def _provision_instance(self, instance_definition: InstanceDefinition, pricing_model: PricingModel, dc_idx: int):
-        return self.provisioners[dc_idx].get_or_create_instance(definition=instance_definition,
-                                                                pricing_model=pricing_model)
+        return provision_instances_with_fallback(self.provisioners[dc_idx], definitions=definitions, pricing_model=pricing_model,
+                                                 fallback_on_demand=self.params.get("instance_provision_fallback_on_demand"))
 
     def get_node_ips_param(self, public_ip=True):
         # todo lukasz: why gce cluster didn't have to implement this?

--- a/sdcm/provision/azure/provisioner.py
+++ b/sdcm/provision/azure/provisioner.py
@@ -67,7 +67,9 @@ class AzureProvisioner(Provisioner):  # pylint: disable=too-many-instance-attrib
 
     def get_or_create_instance(self, definition: InstanceDefinition,
                                pricing_model: PricingModel = PricingModel.SPOT) -> VmInstance:
-        """Create virtual machine in provided region, specified by InstanceDefinition"""
+        """Create virtual machine in provided region, specified by InstanceDefinition.
+
+        Set definition.user_data to empty string when using specialized image."""
         return self.get_or_create_instances(definitions=[definition], pricing_model=pricing_model)[0]
 
     def get_or_create_instances(self,

--- a/sdcm/provision/azure/virtual_machine_provider.py
+++ b/sdcm/provision/azure/virtual_machine_provider.py
@@ -58,7 +58,7 @@ class VirtualMachineProvider:
             LOGGER.info("Instance params: %s", definition)
             params = {
                 "location": self._region,
-                "tags": definition.tags,
+                "tags": definition.tags | {"ssh_user": definition.user_name, "ssh_key": definition.ssh_key.name},
                 "hardware_profile": {
                     "vm_size": definition.type,
                 },
@@ -69,14 +69,14 @@ class VirtualMachineProvider:
                     }],
                 },
             }
-            if definition.user_name is None:
+            if definition.user_name == "specialized":
                 # in case we use specialized image, we don't change things like computer_name, usernames, ssh_keys
                 os_profile = {}
             else:
                 os_profile = self._get_os_profile(computer_name=definition.name,
                                                   admin_username=definition.user_name,
                                                   admin_password=binascii.hexlify(os.urandom(20)).decode(),
-                                                  ssh_public_key=definition.ssh_public_key)
+                                                  ssh_public_key=definition.ssh_key.public_key.decode())
             storage_profile = self._get_scylla_storage_profile(image_id=definition.image_id, name=definition.name,
                                                                disk_size=definition.root_disk_size)
             params.update(os_profile)

--- a/sdcm/provision/helpers/cloud_init.py
+++ b/sdcm/provision/helpers/cloud_init.py
@@ -1,0 +1,60 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+import logging
+
+from sdcm.provision.provisioner import VmInstance
+from sdcm.provision.user_data import CLOUD_INIT_SCRIPTS_PATH
+from sdcm.remote import RemoteCmdRunnerBase
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CloudInitError(Exception):
+    pass
+
+
+def wait_cloud_init_completes(remoter: RemoteCmdRunnerBase, instance: VmInstance):
+    """Connects to VM with SSH and waits for cloud-init to complete. Verify if everything went ok.
+    """
+    LOGGER.info("Waiting for cloud-init to complete on node %s...", instance.name)
+    errors_found = False
+    remoter.is_up(60 * 5)
+    result = remoter.sudo("cloud-init status --wait")
+    status = result.stdout
+    LOGGER.debug("cloud-init status: %s", status)
+    if "done" not in status:
+        LOGGER.error("Some error during cloud-init %s", status)
+        errors_found = True
+    scripts_errors_found = log_user_data_scripts_errors(remoter=remoter)
+    if errors_found or scripts_errors_found:
+        raise CloudInitError("Errors during cloud-init provisioning phase. See logs for errors.")
+
+
+def log_user_data_scripts_errors(remoter: RemoteCmdRunnerBase) -> bool:
+    errors_found = False
+    result = remoter.run(f"ls {CLOUD_INIT_SCRIPTS_PATH}")
+    ls_errors = result.stderr
+    if ls_errors:
+        LOGGER.error("Error listing generated scripts: %s", ls_errors)
+        errors_found = True
+    files_list = result.stdout
+    if not files_list:
+        LOGGER.error("No user data scripts were generated.")
+        errors_found = True
+    elif ".failed" in files_list:
+        LOGGER.error("Some user data scripts have failed: %s", files_list)
+        errors_found = True
+    elif "done" not in files_list:
+        LOGGER.error("User data scripts were not executed at all.")
+        errors_found = True
+    return errors_found

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -14,7 +14,9 @@
 from abc import ABC
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Dict, Optional
+from typing import List, Dict
+
+from sdcm.keystore import SSHKey
 
 
 class VmArch(Enum):
@@ -34,12 +36,12 @@ class InstanceDefinition:  # pylint: disable=too-many-instance-attributes
     name: str
     image_id: str
     type: str   # instance_type from yaml
-    user_name: Optional[str] = None
-    ssh_public_key: Optional[str] = field(default=None, repr=False)
+    user_name: str
+    ssh_key: SSHKey = field(repr=False)
     tags: Dict[str, str] = field(default_factory=dict)
     arch: VmArch = VmArch.X86
-    root_disk_size: Optional[int] = None
-    data_disks: Optional[List[DataDisk]] = None
+    root_disk_size: int | None = None
+    data_disks: List[DataDisk] | None = None
 
 
 class ProvisionError(Exception):
@@ -62,6 +64,7 @@ class VmInstance:  # pylint: disable=too-many-instance-attributes
     name: str
     region: str
     user_name: str
+    ssh_key_name: str
     public_ip_address: str
     private_ip_address: str
     tags: Dict[str, str]

--- a/sdcm/provision/provisioner.py
+++ b/sdcm/provision/provisioner.py
@@ -17,6 +17,7 @@ from enum import Enum
 from typing import List, Dict
 
 from sdcm.keystore import SSHKey
+from sdcm.provision.user_data import UserDataObject
 
 
 class VmArch(Enum):
@@ -42,6 +43,8 @@ class InstanceDefinition:  # pylint: disable=too-many-instance-attributes
     arch: VmArch = VmArch.X86
     root_disk_size: int | None = None
     data_disks: List[DataDisk] | None = None
+    user_data: List[UserDataObject] | None = field(
+        default_factory=list, repr=False)  # None when no cloud-init use at all
 
 
 class ProvisionError(Exception):

--- a/sdcm/provision/user_data.py
+++ b/sdcm/provision/user_data.py
@@ -1,0 +1,123 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import abc
+from dataclasses import dataclass, field
+from textwrap import dedent
+from typing import List, Dict
+
+import yaml
+
+CLOUD_INIT_SCRIPTS_PATH = "/tmp/cloud-init"
+
+
+@dataclass
+class UserDataObject(abc.ABC):
+    """
+    UserDataObject represents installed packages and script that will be executed on the first boot of new VM instance.
+    User data concept comes from 'cloud-init' library. For more info refer cloud-init documentation.
+    """
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    @property
+    def is_applicable(self) -> bool:
+        """Defines if given user data is applicable in given context.
+
+        E.g. workaround for ipv6 only when is AWS and ipv6 configured"""
+        return True
+
+    @property
+    def packages_to_install(self) -> set[str]:
+        """Specifies packages to be installed."""
+        return set()
+
+    @property
+    def script_to_run(self) -> str:
+        """Specifies script that is going to be executed after first boot of VM instance"""
+        return ""
+
+    @property
+    def scylla_machine_image_json(self) -> str:
+        """Specifies configuration file accepted by scylla-machine-image service"""
+        return ""
+
+
+@dataclass
+class UserDataBuilder:
+    """Generates content for cloud-init"""
+    user_data_objects: List[UserDataObject] = field(default_factory=list)
+
+    @property
+    def yum_repos(self) -> Dict:
+        return {
+            "yum_repos":
+                {
+                    "epel-release": {
+                        "baseurl": "http://download.fedoraproject.org/pub/epel/7/$basearch",
+                        "enabled": True,
+                        "failovermethod": "priority",
+                        "gpgcheck": True,
+                        "gpgkey": "http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7",
+                        "name": "Extra Packages for Enterprise Linux 7 - Release"
+                    }
+                }
+        }
+
+    @property
+    def apt_configuration(self) -> Dict:
+        return yaml.safe_load(dedent("""
+                                        apt:
+                                          conf: |
+                                            Acquire::Retries "60";
+                                            DPkg::Lock::Timeout "60";
+                                     """))
+
+    def build_user_data_yaml(self) -> str:
+        """
+        Function creating cloud-init applicable file in yaml format from UserDataObjects.
+
+        For each user data object (with script defined) will generate script file on VM Instance and add it's invocation to runcmd.
+        In case of script execution failure it will create .failed file for each failed script.
+        """
+        packages = set()
+        scripts = []
+        runcmds = []
+        for idx, user_data_object in enumerate(self.user_data_objects):
+            script_path = f"{CLOUD_INIT_SCRIPTS_PATH}/{idx}_{user_data_object.name}.sh"
+            packages.update(user_data_object.packages_to_install)
+            if user_data_object.script_to_run:
+                scripts.append({"content": user_data_object.script_to_run,
+                                "path": script_path,
+                                "permissions": "0644"
+                                })
+                runcmds.append(
+                    f"cd {CLOUD_INIT_SCRIPTS_PATH}; bash -eux {script_path}; test  $? = 0 || touch {script_path}.failed")
+        # in case of problems with creating scripts, cloud-init won't run anything and will not report any error
+        # to fix it create 'done' file as last step to enable further verification if executed at all
+        runcmds.append(f"mkdir -p {CLOUD_INIT_SCRIPTS_PATH} && touch {CLOUD_INIT_SCRIPTS_PATH}/done")
+        user_data_yaml = yaml.dump(data={
+            "packages": list(packages),
+            "write_files": scripts,
+            "runcmd": runcmds
+        } | self.yum_repos | self.apt_configuration)
+        return "#cloud-config\n" + user_data_yaml
+
+    def get_scylla_machine_image_json(self):
+        """Returns json applicable for scylla-machine-image service."""
+        for user_data_object in self.user_data_objects:
+            if smi_json := user_data_object.scylla_machine_image_json:
+                return smi_json
+        return ""

--- a/sdcm/sct_config.py
+++ b/sdcm/sct_config.py
@@ -1500,7 +1500,13 @@ class SCTConfiguration(dict):
                 self.log.debug("Found GCE image %s for scylla_version='%s'", gce_image.name, scylla_version)
                 self["gce_image_db"] = gce_image.extra["selfLink"]
             elif not self.get("azure_image_db") and self.get("cluster_backend") == "azure":
-                self["azure_image_db"] = get_scylla_images(scylla_version, self.get('azure_region_name'))[0].id
+                scylla_azure_images = []
+                for region in self.get('azure_region_name'):
+                    azure_image = get_scylla_images(scylla_version, region)[0]
+                    self.log.debug("Found AMI %s for scylla_version='%s' in %s",
+                                   azure_image.name, scylla_version, region)
+                    scylla_azure_images.append(azure_image)
+                self["azure_image_db"] = " ".join(image.id for image in scylla_azure_images)
             elif not self.get('scylla_repo'):
                 self['scylla_repo'] = find_scylla_repo(scylla_version, dist_type, dist_version)
             else:

--- a/sdcm/sct_provision/azure/azure_instance_request_definition_builder.py
+++ b/sdcm/sct_provision/azure/azure_instance_request_definition_builder.py
@@ -11,13 +11,13 @@
 #
 # Copyright (c) 2022 ScyllaDB
 from dataclasses import dataclass
-from typing import List, Literal, Dict
+from typing import List, Dict
 
 from sdcm.cluster import DEFAULT_USER_PREFIX
 from sdcm.keystore import KeyStore
 from sdcm.provision.provisioner import InstanceDefinition
 from sdcm.sct_config import SCTConfiguration
-from sdcm.sct_provision.instances_request_definition_builder import InstancesRequest
+from sdcm.sct_provision.instances_request_definition_builder import InstancesRequest, NodeTypeType
 from sdcm.test_config import TestConfig
 
 
@@ -45,7 +45,7 @@ monitor_map = ConfigParamsMap(image_id="azure_image_monitor",
                               user_name="ami_monitor_user",
                               root_disk_size="azure_root_disk_size_monitor")
 
-mappers: Dict[str, ConfigParamsMap] = {"db": db_map,
+mappers: Dict[str, ConfigParamsMap] = {"scylla-db": db_map,
                                        "loader": loader_map,
                                        "monitor": monitor_map}
 
@@ -60,25 +60,27 @@ def get_node_count_for_each_region(sct_config: SCTConfiguration, n_str: str) -> 
     return ([int(v) for v in str(n_str).split()] + [0] * region_count)[:region_count]
 
 
-def generate_instance_definition_params(sct_config: SCTConfiguration, node_type: Literal["db", "loader", "monitor"], region: str,
-                                        index: int) -> Dict[str, str]:
+def generate_instance_definition(sct_config: SCTConfiguration,
+                                 node_type: NodeTypeType, region: str,
+                                 index: int) -> InstanceDefinition:
     """Generates parameters for InstanceDefinition based on node_type and SCT Configuration."""
     user_prefix = sct_config.get('user_prefix') or DEFAULT_USER_PREFIX
     common_tags = TestConfig.common_tags()
-    name = f"{user_prefix}-{node_type}-node-{region}-{index}".lower()
-    action = sct_config.get(f"post_behavior_{node_type}_nodes")
+    node_type_short = "db" if "db" in node_type else node_type
+    name = f"{user_prefix}-{node_type_short}-node-{region}-{index}".lower()
+    action = sct_config.get(f"post_behavior_{node_type_short}_nodes")
     tags = common_tags | {"NodeType": node_type,
-                          "keep_action": "terminate" if action == "destroy" else ""}
-    ssh_public_key = KeyStore().get_gce_ssh_key_pair().public_key.decode()
+                          "keep_action": "terminate" if action == "destroy" else "",
+                          "NodeIndex": str(index)}
+    ssh_key = KeyStore().get_gce_ssh_key_pair()
     mapper = mappers[node_type]
-    params = {"name": name,
-              "image_id": sct_config.get(mapper.image_id),
-              "type": sct_config.get(mapper.type),
-              "user_name": sct_config.get(mapper.user_name),
-              "root_disk_size": sct_config.get(mapper.root_disk_size),
-              "tags": tags,
-              "ssh_public_key": ssh_public_key}
-    return params
+    return InstanceDefinition(name=name,
+                              image_id=sct_config.get(mapper.image_id),
+                              type=sct_config.get(mapper.type),
+                              user_name=sct_config.get(mapper.user_name),
+                              root_disk_size=sct_config.get(mapper.root_disk_size),
+                              tags=tags,
+                              ssh_key=ssh_key)
 
 
 def azure_instance_request_builder(sct_config: SCTConfiguration) -> List[InstancesRequest]:
@@ -90,20 +92,23 @@ def azure_instance_request_builder(sct_config: SCTConfiguration) -> List[Instanc
 
     for region, db_nodes, loader_nodes, monitor_nodes in zip(
             sct_config.get("azure_region_name"), n_db_nodes, n_loader_nodes, n_monitor_nodes):
-        params_list = []
+        definitions = []
         for idx in range(db_nodes):
-            params_list.append(generate_instance_definition_params(
-                sct_config=sct_config, node_type="db", region=region, index=idx+1))
+            definitions.append(
+                generate_instance_definition(sct_config=sct_config, node_type="scylla-db", region=region, index=idx+1)
+            )
 
         for idx in range(loader_nodes):
-            params_list.append(generate_instance_definition_params(
-                sct_config=sct_config, node_type="loader", region=region, index=idx+1))
+            definitions.append(
+                generate_instance_definition(sct_config=sct_config, node_type="loader", region=region, index=idx+1)
+            )
 
         for idx in range(monitor_nodes):
-            params_list.append(generate_instance_definition_params(
-                sct_config=sct_config, node_type="monitor", region=region, index=idx+1))
+            definitions.append(
+                generate_instance_definition(sct_config=sct_config, node_type="monitor", region=region, index=idx+1)
+            )
 
-        definitions = [InstanceDefinition(**params) for params in params_list]
-        requests.append(InstancesRequest(backend="azure", test_id=sct_config.get(
-            "test_id"), region=region, definitions=definitions))
+        requests.append(
+            InstancesRequest(backend="azure", test_id=sct_config.get("test_id"), region=region, definitions=definitions)
+        )
     return requests

--- a/sdcm/sct_provision/instances_request_definition_builder.py
+++ b/sdcm/sct_provision/instances_request_definition_builder.py
@@ -16,7 +16,7 @@ from typing import Callable, List, Literal
 
 from sdcm.provision.provisioner import InstanceDefinition
 from sdcm.sct_config import SCTConfiguration
-
+from sdcm.test_config import TestConfig
 
 NodeTypeType = Literal["scylla-db", "loader", "monitor"]
 
@@ -46,9 +46,9 @@ class InstancesRequestBuilder:
         Must be used before calling InstancesRequestBuilder for given backend."""
         self._functions[backend] = builder_function
 
-    def build(self, sct_config: SCTConfiguration) -> List[InstancesRequest]:
+    def build(self, sct_config: SCTConfiguration, test_config: TestConfig) -> List[InstancesRequest]:
         """Creates InstancesRequest for each region based on SCTConfiguration.
 
         Prior use, must register builder for given backend."""
         backend = sct_config.get("cluster_backend")
-        return self._functions[backend](sct_config)
+        return self._functions[backend](sct_config, test_config)

--- a/sdcm/sct_provision/instances_request_definition_builder.py
+++ b/sdcm/sct_provision/instances_request_definition_builder.py
@@ -12,10 +12,13 @@
 # Copyright (c) 2022 ScyllaDB
 
 from dataclasses import dataclass
-from typing import Callable, List
+from typing import Callable, List, Literal
 
 from sdcm.provision.provisioner import InstanceDefinition
 from sdcm.sct_config import SCTConfiguration
+
+
+NodeTypeType = Literal["scylla-db", "loader", "monitor"]
 
 
 @dataclass

--- a/sdcm/sct_provision/user_data.py
+++ b/sdcm/sct_provision/user_data.py
@@ -1,0 +1,37 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+from typing import List, Type
+
+from sdcm.sct_config import SCTConfiguration
+from sdcm.sct_provision.instances_request_definition_builder import NodeTypeType
+from sdcm.sct_provision.user_data_objects import SctUserDataObject
+from sdcm.sct_provision.user_data_objects.scylla import ScyllaUserDataObject
+from sdcm.sct_provision.user_data_objects.sshd import SshdUserDataObject
+from sdcm.sct_provision.user_data_objects.syslog_ng import SyslogNgUserDataObject
+from sdcm.test_config import TestConfig
+
+
+def get_user_data_objects(test_config: TestConfig, sct_config: SCTConfiguration, instance_name: str, node_type: NodeTypeType
+                          ) -> List[SctUserDataObject]:
+    user_data_object_classes: List[Type[SctUserDataObject]] = [
+        SyslogNgUserDataObject,
+        SshdUserDataObject,
+        ScyllaUserDataObject,
+    ]
+    user_data_objects = [
+        klass(test_config=test_config, sct_config=sct_config, instance_name=instance_name, node_type=node_type)
+        for klass in user_data_object_classes
+    ]
+    applicable_user_data_objects = [obj for obj in user_data_objects if obj.is_applicable]
+    return applicable_user_data_objects

--- a/sdcm/sct_provision/user_data_objects/__init__.py
+++ b/sdcm/sct_provision/user_data_objects/__init__.py
@@ -1,0 +1,26 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+from dataclasses import dataclass
+
+from sdcm.provision.user_data import UserDataObject
+from sdcm.sct_config import SCTConfiguration
+from sdcm.sct_provision.instances_request_definition_builder import NodeTypeType
+from sdcm.test_config import TestConfig
+
+
+@dataclass
+class SctUserDataObject(UserDataObject):
+    test_config: TestConfig
+    sct_config: SCTConfiguration
+    instance_name: str
+    node_type: NodeTypeType

--- a/sdcm/sct_provision/user_data_objects/scylla.py
+++ b/sdcm/sct_provision/user_data_objects/scylla.py
@@ -1,0 +1,34 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+from dataclasses import dataclass
+from textwrap import dedent
+
+from sdcm.sct_provision.user_data_objects import SctUserDataObject
+
+
+@dataclass
+class ScyllaUserDataObject(SctUserDataObject):
+
+    @property
+    def is_applicable(self) -> bool:
+        return self.node_type == "scylla-db"
+
+    @property
+    def scylla_machine_image_json(self) -> str:
+        """Specifies configuration file accepted by scylla-machine-image service"""
+        return dedent("""{
+                     "scylla_yaml": {
+                         "experimental": true
+                     },
+                     "start_scylla_on_first_boot": false
+                }""")

--- a/sdcm/sct_provision/user_data_objects/sshd.py
+++ b/sdcm/sct_provision/user_data_objects/sshd.py
@@ -1,0 +1,30 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+from dataclasses import dataclass
+
+from sdcm.provision.common.utils import configure_sshd_script, restart_sshd_service
+from sdcm.sct_provision.user_data_objects import SctUserDataObject
+
+
+@dataclass
+class SshdUserDataObject(SctUserDataObject):
+
+    @property
+    def is_applicable(self) -> bool:
+        return True
+
+    @property
+    def script_to_run(self) -> str:
+        script = configure_sshd_script()
+        script += restart_sshd_service()
+        return script

--- a/sdcm/sct_provision/user_data_objects/syslog_ng.py
+++ b/sdcm/sct_provision/user_data_objects/syslog_ng.py
@@ -1,0 +1,39 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+from dataclasses import dataclass
+
+from sdcm.provision.common.configuration_script import SYSLOGNG_LOG_THROTTLE_PER_SECOND
+from sdcm.provision.common.utils import configure_syslogng_target_script, restart_syslogng_service
+from sdcm.sct_provision.user_data_objects import SctUserDataObject
+
+
+@dataclass
+class SyslogNgUserDataObject(SctUserDataObject):
+
+    @property
+    def is_applicable(self) -> bool:
+        return self.sct_config.get('logs_transport') == 'syslog-ng'
+
+    @property
+    def packages_to_install(self) -> set[str]:
+        return {"syslog-ng"}
+
+    @property
+    def script_to_run(self) -> str:
+        host, port = self.test_config.get_logging_service_host_port()
+        script = configure_syslogng_target_script(host=host,
+                                                  port=port,
+                                                  throttle_per_second=SYSLOGNG_LOG_THROTTLE_PER_SECOND,
+                                                  hostname=self.instance_name)
+        script += restart_syslogng_service()
+        return script

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -819,8 +819,8 @@ class AzureSctRunner(SctRunner):
             vm_params = InstanceDefinition(name=instance_name,
                                            image_id=base_image["id"],
                                            type=instance_type,
-                                           user_name=None,
-                                           ssh_public_key=None,
+                                           user_name="specialized",
+                                           ssh_key=self.key_pair,
                                            tags=tags | {"launch_time": get_current_datetime_formatted()},
                                            root_disk_size=self.instance_root_disk_size(test_duration=test_duration))
             return provisioner.get_or_create_instance(definition=vm_params,

--- a/sdcm/sct_runner.py
+++ b/sdcm/sct_runner.py
@@ -819,10 +819,11 @@ class AzureSctRunner(SctRunner):
             vm_params = InstanceDefinition(name=instance_name,
                                            image_id=base_image["id"],
                                            type=instance_type,
-                                           user_name="specialized",
+                                           user_name=self.LOGIN_USER,
                                            ssh_key=self.key_pair,
                                            tags=tags | {"launch_time": get_current_datetime_formatted()},
-                                           root_disk_size=self.instance_root_disk_size(test_duration=test_duration))
+                                           root_disk_size=self.instance_root_disk_size(test_duration=test_duration),
+                                           user_data=None)
             return provisioner.get_or_create_instance(definition=vm_params,
                                                       pricing_model=PricingModel.ON_DEMAND)
 

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -21,12 +21,14 @@ import pytest
 from sdcm import wait
 from sdcm.cluster import BaseNode
 from sdcm.prometheus import start_metrics_server
+from sdcm.remote import RemoteCmdRunnerBase
 from sdcm.utils.docker_remote import RemoteDocker
 
 
 from unit_tests.dummy_remote import LocalNode, LocalScyllaClusterDummy
 
 from unit_tests.lib.events_utils import EventsUtilsMixin
+from unit_tests.lib.fake_remoter import FakeRemoter
 
 
 @pytest.fixture(scope='session')
@@ -83,3 +85,9 @@ def docker_scylla():
     yield scylla
 
     scylla.kill()
+
+
+@pytest.fixture
+def fake_remoter():
+    RemoteCmdRunnerBase.set_default_remoter_class(FakeRemoter)
+    return FakeRemoter

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -23,6 +23,7 @@ from sdcm.cluster import BaseNode
 from sdcm.prometheus import start_metrics_server
 from sdcm.utils.docker_remote import RemoteDocker
 
+
 from unit_tests.dummy_remote import LocalNode, LocalScyllaClusterDummy
 
 from unit_tests.lib.events_utils import EventsUtilsMixin

--- a/unit_tests/lib/fake_remoter.py
+++ b/unit_tests/lib/fake_remoter.py
@@ -1,0 +1,59 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import re
+from typing import Dict, Pattern, Optional, List
+
+from invoke import Result, StreamWatcher
+
+from sdcm.remote import RemoteCmdRunnerBase
+
+
+class FakeRemoter(RemoteCmdRunnerBase):
+    """Fake remoter that responds to commands as described in `result_map` class attribute."""
+
+    result_map: Dict[Pattern, Result] = {}
+
+    def run(self,  # pylint: disable=too-many-arguments
+            cmd: str,
+            timeout: Optional[float] = None,
+            ignore_status: bool = False,
+            verbose: bool = True,
+            new_session: bool = False,
+            log_file: Optional[str] = None,
+            retry: int = 1,
+            watchers: Optional[List[StreamWatcher]] = None,
+            change_context: bool = False
+            ) -> Result:
+        for pattern, result in self.result_map.items():
+            if re.match(pattern, cmd) is not None:
+                if ignore_status is True:
+                    return result
+                else:
+                    if result.failed:
+                        raise Exception(f"Exception occurred when running command: {cmd}")
+                    return result
+        raise ValueError(f"No fake result specified for command: {cmd}."
+                         f"Set {self.__class__.__name__}.result_map variable with Dict[Pattern, Result] mapping")
+
+    def _create_connection(self):
+        pass
+
+    def _close_connection(self):
+        pass
+
+    def is_up(self, timeout: float = 30):
+        return True
+
+    def _run_on_retryable_exception(self, exc: Exception, new_session: bool) -> bool:
+        return True

--- a/unit_tests/provisioner/conftest.py
+++ b/unit_tests/provisioner/conftest.py
@@ -18,7 +18,9 @@ from pathlib import Path
 
 import pytest
 
+from sct import get_test_config
 from sdcm.sct_config import SCTConfiguration
+from sdcm.test_config import TestConfig
 from sdcm.utils.azure_utils import AzureService  # pylint: disable=import-error
 from unit_tests.provisioner.fake_azure_service import FakeAzureService  # pylint: disable=import-error
 
@@ -59,3 +61,10 @@ def sct_config():
     )
     os.environ.update(env_config._asdict())
     return SCTConfiguration()
+
+
+@pytest.fixture
+def test_config(sct_config):  # pylint: disable=unused-argument,redefined-outer-name
+    config = get_test_config()
+    TestConfig.RSYSLOG_ADDRESS = ("localhost", 12345)
+    return config

--- a/unit_tests/provisioner/fake_azure_service.py
+++ b/unit_tests/provisioner/fake_azure_service.py
@@ -435,11 +435,11 @@ class FakeVirtualMachines:
 
     def begin_create_or_update(self, resource_group_name: str, vm_name: str, parameters: Dict[str, Any]
                                ) -> WaitableObject:
+        tags = parameters.pop("tags") if "tags" in parameters else {}
         parameters = dict_keys_to_camel_case(parameters)
         location = parameters.pop("location")
-        tags = parameters.pop("tags")
         priority = parameters.get("priority") or ""
-        if tags.get("JenkinsJobTag") == "FailSpotDB" and priority.lower() == "spot" and tags.get("NodeType") == "db":
+        if tags.get("JenkinsJobTag") == "FailSpotDB" and priority.lower() == "spot" and tags.get("NodeType") == "scylla-db":
             # for testing fallback on demand
             raise AzureError("Failing creating db spot instance because JenkinsJobTag is FailSpotDB")
 

--- a/unit_tests/provisioner/test_azure_instance_request_builder.py
+++ b/unit_tests/provisioner/test_azure_instance_request_builder.py
@@ -45,7 +45,8 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
     tags = TestConfig.common_tags()
     ssh_key = KeyStore().get_gce_ssh_key_pair()
     prefix = config.get('user_prefix')
-    instance_requests = instances_request_builder.build(sct_config=config)
+    test_config = TestConfig()
+    instance_requests = instances_request_builder.build(sct_config=config, test_config=test_config)
 
     definition = InstanceDefinition(name=f"{prefix}-db-node-eastus-1", image_id=env_config.SCT_AZURE_IMAGE_DB,
                                     type="Standard_L8s_v2", user_name="scyllaadm", root_disk_size=30,
@@ -57,5 +58,6 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
     assert actual_request.test_id == env_config.SCT_TEST_ID
     assert actual_request.backend == "azure"
     assert actual_request.region == "eastus"
+    actual_request.definitions[0].user_data = definition.user_data  # ignoring user_data in this validation
     # ssh_key is not shown, if actual looks the same as expected possibly ssh_key differ
     assert definition == actual_request.definitions[0]

--- a/unit_tests/provisioner/test_azure_instance_request_builder.py
+++ b/unit_tests/provisioner/test_azure_instance_request_builder.py
@@ -43,18 +43,19 @@ def test_can_create_basic_scylla_instance_definition_from_sct_config():
     os.environ.update(env_config._asdict())
     config = SCTConfiguration()
     tags = TestConfig.common_tags()
-    ssh_public_key = KeyStore().get_gce_ssh_key_pair().public_key.decode()
+    ssh_key = KeyStore().get_gce_ssh_key_pair()
     prefix = config.get('user_prefix')
     instance_requests = instances_request_builder.build(sct_config=config)
 
     definition = InstanceDefinition(name=f"{prefix}-db-node-eastus-1", image_id=env_config.SCT_AZURE_IMAGE_DB,
                                     type="Standard_L8s_v2", user_name="scyllaadm", root_disk_size=30,
-                                    tags=tags | {"NodeType": "db", "keep_action": ""},
-                                    ssh_public_key=ssh_public_key)
+                                    tags=tags | {"NodeType": "scylla-db", "keep_action": "", 'NodeIndex': '1'},
+                                    ssh_key=ssh_key)
     assert len(instance_requests) == 2
     actual_request = instance_requests[0]
+
     assert actual_request.test_id == env_config.SCT_TEST_ID
     assert actual_request.backend == "azure"
     assert actual_request.region == "eastus"
-    assert actual_request.definitions[0] == definition  # remember ssh_public_key is not shown
-    # - if actual looks the same as expected possibly ssh_public_key differ
+    # ssh_key is not shown, if actual looks the same as expected possibly ssh_key differ
+    assert definition == actual_request.definitions[0]

--- a/unit_tests/provisioner/test_azure_provisioner.py
+++ b/unit_tests/provisioner/test_azure_provisioner.py
@@ -41,7 +41,7 @@ class TestProvisionScyllaInstanceAzureE2E:
             image_id=image_id,
             type="Standard_D2s_v3",
             user_name="tester",
-            ssh_public_key=KeyStore().get_ec2_ssh_key_pair().public_key.decode(),
+            ssh_key=KeyStore().get_ec2_ssh_key_pair(),
             tags={'test-tag': 'test_value'}
         )
 

--- a/unit_tests/provisioner/test_azure_provisioner.py
+++ b/unit_tests/provisioner/test_azure_provisioner.py
@@ -18,6 +18,32 @@ from azure.core.exceptions import ResourceNotFoundError
 from sdcm.keystore import KeyStore  # pylint: disable=import-error
 from sdcm.provision.azure.utils import get_scylla_images  # pylint: disable=import-error
 from sdcm.provision.provisioner import InstanceDefinition, provisioner_factory  # pylint: disable=import-error
+from sdcm.provision.user_data import UserDataObject
+
+
+class PrintingTestUserDataObject(UserDataObject):
+
+    @property
+    def script_to_run(self) -> str:
+        return """echo OK
+        echo another command"""
+
+
+class FailingTestUserDataObject(UserDataObject):
+
+    @property
+    def script_to_run(self) -> str:
+        return """echo is ok
+        this_command_does_not_exist
+        echo this should not happen"""
+
+
+class PrintingTwoTestUserDataObject(UserDataObject):
+
+    @property
+    def script_to_run(self) -> str:
+        return """echo something
+        echo something again"""
 
 
 class TestProvisionScyllaInstanceAzureE2E:
@@ -42,7 +68,8 @@ class TestProvisionScyllaInstanceAzureE2E:
             type="Standard_D2s_v3",
             user_name="tester",
             ssh_key=KeyStore().get_ec2_ssh_key_pair(),
-            tags={'test-tag': 'test_value'}
+            tags={'test-tag': 'test_value'},
+            user_data=[PrintingTestUserDataObject(), FailingTestUserDataObject(), PrintingTwoTestUserDataObject()]
         )
 
     @pytest.fixture(scope="session")

--- a/unit_tests/provisioner/test_provision_sct_resources.py
+++ b/unit_tests/provisioner/test_provision_sct_resources.py
@@ -23,7 +23,7 @@ def test_can_provision_instances_according_to_sct_configuration(sct_config, azur
     provisioner_eastus = provisioner_factory.create_provisioner(
         backend="azure", test_id=sct_config.get("test_id"), region="eastus", azure_service=azure_service)
     eastus_instances = provisioner_eastus.list_instances()
-    db_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "db"]
+    db_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "scylla-db"]
     loader_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "loader"]
     monitor_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "monitor"]
 
@@ -32,13 +32,13 @@ def test_can_provision_instances_according_to_sct_configuration(sct_config, azur
     assert len(monitor_nodes) == 1
     db_node = db_nodes[0]
     assert db_node.region == "eastus"
-    assert list(db_node.tags.keys()) == list(tags.keys()) + ["NodeType", "keepAction"]
+    assert list(db_node.tags.keys()) == list(tags.keys()) + ["NodeType", "keep_action", "NodeIndex"]
     assert db_node.pricing_model == PricingModel.SPOT
 
     provisioner_easteu = provisioner_factory.create_provisioner(backend="azure", test_id=sct_config.get("test_id"),
                                                                 region="easteu", azure_service=azure_service)
     easteu_instances = provisioner_easteu.list_instances()
-    db_nodes = [node for node in easteu_instances if node.tags['NodeType'] == "db"]
+    db_nodes = [node for node in easteu_instances if node.tags['NodeType'] == "scylla-db"]
     loader_nodes = [node for node in easteu_instances if node.tags['NodeType'] == "loader"]
     monitor_nodes = [node for node in easteu_instances if node.tags['NodeType'] == "monitor"]
 
@@ -47,7 +47,7 @@ def test_can_provision_instances_according_to_sct_configuration(sct_config, azur
     assert len(monitor_nodes) == 0
     db_node = db_nodes[0]
     assert db_node.region == "easteu"
-    assert list(db_node.tags.keys()) == list(tags.keys()) + ["NodeType", "keepAction"]
+    assert list(db_node.tags.keys()) == list(tags.keys()) + ["NodeType", "keep_action", "NodeIndex"]
     assert db_node.pricing_model == PricingModel.SPOT
 
 
@@ -57,7 +57,7 @@ def test_fallback_on_demand_when_spot_fails(fallback_on_demand, sct_config, azur
     provisioner_eastus = provisioner_factory.create_provisioner(
         backend="azure", test_id=sct_config.get("test_id"), region="eastus", azure_service=azure_service)
     eastus_instances = provisioner_eastus.list_instances()
-    db_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "db"]
+    db_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "scylla-db"]
     loader_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "loader"]
     monitor_nodes = [node for node in eastus_instances if node.tags['NodeType'] == "monitor"]
 

--- a/unit_tests/provisioner/test_user_data_builder.py
+++ b/unit_tests/provisioner/test_user_data_builder.py
@@ -1,0 +1,113 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright (c) 2022 ScyllaDB
+
+import yaml
+
+from sdcm.provision.user_data import UserDataObject, UserDataBuilder
+
+
+class ExampleUserDataObject(UserDataObject):
+
+    @property
+    def packages_to_install(self) -> set[str]:
+        return {"some-pkg-to-install"}
+
+    @property
+    def script_to_run(self) -> str:
+        return """
+        Some script
+        that spans multiple lines
+        """
+
+
+class AnotherExampleUserDataObject(UserDataObject):
+
+    @property
+    def packages_to_install(self) -> set[str]:
+        return {"another-pkg-to-install"}
+
+    @property
+    def script_to_run(self) -> str:
+        return """
+        Just another script
+        """
+
+
+class EmptyScriptUserDataObject(UserDataObject):
+
+    @property
+    def packages_to_install(self) -> set[str]:
+        return {"pkg-from-empty", "another-pkg-to-install"}
+
+
+class NotApplicableUserDataObject(UserDataObject):
+
+    @property
+    def is_applicable(self) -> bool:
+        return False
+
+
+def test_user_data_builder_generates_valid_yaml_from_single_user_data_object():
+    user_data_object_1 = ExampleUserDataObject()
+
+    builder = UserDataBuilder(user_data_objects=[user_data_object_1])
+    user_data_yaml = builder.build_user_data_yaml()
+    loaded_yaml = yaml.load(user_data_yaml)
+
+    assert user_data_yaml.startswith("#cloud-config\n"), "user-data yaml must start with #cloud-config"
+    assert loaded_yaml['packages'] == ['some-pkg-to-install']
+    assert loaded_yaml['runcmd'][0] == \
+        "cd /tmp/cloud-init; bash -eux /tmp/cloud-init/0_ExampleUserDataObject.sh; test  $? = 0 " \
+        "|| touch /tmp/cloud-init/0_ExampleUserDataObject.sh.failed"
+    script_file = loaded_yaml['write_files'][0]
+    assert script_file["path"] == "/tmp/cloud-init/0_ExampleUserDataObject.sh"
+    assert user_data_object_1.script_to_run in script_file["content"]
+    assert script_file["permissions"] == '0644'
+    assert loaded_yaml['runcmd'][1] == "mkdir -p /tmp/cloud-init && touch /tmp/cloud-init/done"
+
+
+def test_user_data_can_merge_user_data_objects_yaml():
+    user_data_object_1 = ExampleUserDataObject()
+    user_data_object_2 = AnotherExampleUserDataObject()
+    user_data_object_3 = EmptyScriptUserDataObject()
+
+    builder = UserDataBuilder(user_data_objects=[user_data_object_1, user_data_object_2, user_data_object_3])
+    user_data_yaml = builder.build_user_data_yaml()
+    loaded_yaml = yaml.load(user_data_yaml)
+
+    assert sorted(loaded_yaml['packages']) == sorted(
+        ['some-pkg-to-install', 'another-pkg-to-install', 'pkg-from-empty'])
+    script_files = loaded_yaml['write_files']
+    assert len(script_files) == 2, "empty script user data object should not be added"
+    assert user_data_object_1.script_to_run in script_files[0]["content"]
+    assert user_data_object_2.script_to_run in script_files[1]["content"]
+
+
+def test_only_done_runcmd_in_yaml_when_no_user_data_objects():
+    builder = UserDataBuilder(user_data_objects=[])
+    user_data_yaml = builder.build_user_data_yaml()
+    loaded_yaml = yaml.load(user_data_yaml)
+
+    assert not loaded_yaml["packages"]
+    assert not loaded_yaml["write_files"]
+    assert loaded_yaml["runcmd"] == ['mkdir -p /tmp/cloud-init && touch /tmp/cloud-init/done']
+
+
+def test_only_done_runcmd_in_yaml_when_no_applicable_user_data_objects():
+    builder = UserDataBuilder(user_data_objects=[NotApplicableUserDataObject()])
+    user_data_yaml = builder.build_user_data_yaml()
+    loaded_yaml = yaml.load(user_data_yaml)
+
+    assert not loaded_yaml["packages"]
+    assert not loaded_yaml["write_files"]
+    assert loaded_yaml["runcmd"] == ['mkdir -p /tmp/cloud-init && touch /tmp/cloud-init/done']


### PR DESCRIPTION
Introduced concept of UserDataObjects that each define packages to install,
script to execute, and possibly changes in scylla user-data json
(acceptable by scylla-machine-image). Provisioners will be building
cloud-init compatible yaml out of these objects and provide it in
user-data (custom_data in Azure) parameter for instances creation.

Current solution will work only for Azure, as Azure uses custom-data for
cloud-init yaml (or script) and user-data for user purpose (which is
used by scylla-machine-image). Azure provider makes use of this behavior.
On AWS/GCE scylla-machine-image will fail on loading cloud-init
compatible yaml. Adding this feature is planned to be added, so users
will be able still using both cloud-init and scylla-machine-image.

Json generation for scylla-machine-image is not yet complete and
requires improvments, as currently it's static.
I propose to do it in separate PR, as Scylla configuration is not trivial.

## PR pre-checks (self review)
<!--- PR should be created as Draft, when CI finished and relevant checkboxes selected, add reviewers and then click on "Ready for review" button.-->
<!--- Put an `x` in all the boxes that apply or create PR and then click on all relevant checkboxes: -->
- [ ] I followed [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) and [best practices](https://docs.google.com/document/d/1jihgOKb5iGRlD8_HQ92O0JbLk1kASUoZT23i_MXFSKI)
- [ ] I didn't leave commented-out/debugging code
- [ ] I added the relevant `backport` labels
- [ ] New configuration option are added and documented (in `sdcm/sct_config.py`)
- [ ] I have added tests to cover my changes (Infrastructure only - under `unit-test/` folder)
- [ ] All new and existing unit tests passed (CI)
- [ ] I have updated the Readme/doc folder accordingly (if needed)
